### PR TITLE
Fix version file URL property

### DIFF
--- a/SSTUWaterfall/SSTUWaterfall.version
+++ b/SSTUWaterfall/SSTUWaterfall.version
@@ -1,6 +1,6 @@
 {
 	"NAME": "SSTUWaterfall",
-	"URL": "https://github.com/Briso8/SSTUWaterfall/releases/tag/1.1",
+	"URL": "https://github.com/Briso8/SSTUWaterfall/raw/main/SSTUWaterfall/SSTUWaterfall.version",
 
 	"VERSION":
 	{


### PR DESCRIPTION
Hi @Briso8, 

The version file's URL property is supposed to point to an online copy of the version file itself, not the release. This pull request fixes it.

Noticed while checking on KSP-CKAN/NetKAN#8562.